### PR TITLE
Support redirection to relative URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,12 +57,19 @@ def expander(self):
 
                 if response.status_code in (300, 301, 302, 303, 307):
                     if "location" in response.headers:
-                        url = response.headers["location"]
+                        location = response.headers["location"]
                     elif "Location" in response.headers:
-                        url = response.headers["Location"]
+                        location = response.headers["Location"]
                     else:
                         data["status"] = "OK"
                         break
+                    # check if the url is relative or absolute
+                    if location.startswith('/'):
+                        parsedloc = list(urlparse.urlparse(location))
+                        parsedurl = list(urlparse.urlparse(url))
+                        url = urlparse.urlunparse(parsedurl[:2] + parsedloc[2:])
+                    else:
+                        url = location
                 else:
                     # no more redirects; we're done
                     data["status"] = "OK"


### PR DESCRIPTION
As seen on RFC 7231 (https://tools.ietf.org/html/rfc7231#section-7.1.2)

Currently the expander stops with "InvalidURL" error if it encounters a relative URL:
- https://expandurl.appspot.com/expand?url=http://bit.ly/1jeeF3p

vs
- https://expandurl-1.appspot.com/expand?url=http://bit.ly/1jeeF3p
- http://longurl.org/expand?url=http%3A%2F%2Fbit.ly%2F1jeeF3p